### PR TITLE
Run controller deployment on control-plane nodes

### DIFF
--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -171,7 +171,8 @@ controller:
   # ID of the Kubernetes cluster used for tagging provisioned EBS volumes (optional).
   k8sTagClusterId:
   logLevel: 2
-  nodeSelector: {}
+  nodeSelector:
+    node-role.kubernetes.io/control-plane: ""
   podAnnotations: {}
   podLabels: {}
   priorityClassName: system-cluster-critical
@@ -204,9 +205,18 @@ controller:
   tolerations:
     - key: CriticalAddonsOnly
       operator: Exists
-    - effect: NoExecute
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
       operator: Exists
-      tolerationSeconds: 300
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+      operator: Exists
+    - effect: NoSchedule
+      key: node.cloudprovider.kubernetes.io/uninitialized
+      operator: Exists
+    - effect: NoSchedule
+      key: node.kubernetes.io/not-ready
+      operator: Exists
   # TSCs without the label selector stanza
   #
   # Example:


### PR DESCRIPTION
Add tolerations and node selector to run the CSI controller service on control-plane nodes

Fixes https://github.com/edgelesssys/constellation/pull/1993